### PR TITLE
Add shared-services state backend

### DIFF
--- a/infrastructure/backends.auto.tfvars
+++ b/infrastructure/backends.auto.tfvars
@@ -29,4 +29,12 @@ ad_backends = {
     ]
     pulumi_keys = ["infra-azure-frontdoor"]
   }
+  shared-services = {
+    name = "shared-services"
+    repo = "https://github.com/badbort/shared-services"
+    identities = [
+      "github-actions-shared-services-infra",
+      "github-actions-shared-services-plan",
+    ]
+  }
 }


### PR DESCRIPTION
Adds `shared-services` entry to `ad_backends` in `infrastructure/backends.auto.tfvars`.

Provisions a private blob container `shared-services` on `badbortcommontfstatesta` for `badbort/shared-services` and grants:

- `github-actions-shared-services-infra` — Storage Blob Data Contributor
- `github-actions-shared-services-plan` — Storage Blob Data Contributor

Terraform-only (no `pulumi_keys`).

**Note:** depends on `badbort/infra-azure-foundations` PR for RG `shared-services-ae` being merged and applied first — `terraform plan` will fail until those SPs exist in the tenant.